### PR TITLE
Add wrapper for certain handlers that cleans the cache

### DIFF
--- a/pkg/utils/handler.go
+++ b/pkg/utils/handler.go
@@ -18,14 +18,18 @@ type Handler struct {
 
 func NewHandler(createKubeClient bool) (*Handler, error) {
 	h := &Handler{AgentCache: map[string]AgentInfo{}}
-	h.SetupRouter()
-	h.AddMiddleware()
 
 	var err error
 	if createKubeClient {
 		kProxy := &KubeProxy{}
 		err = kProxy.SetupClientSet()
+		if err == nil {
+			h.KubeClient = kProxy
+		}
 	}
+
+	h.SetupRouter()
+	h.AddMiddleware()
 
 	return h, err
 }


### PR DESCRIPTION
Before returning result to the user cache must be cleaned from stalled
agents (i.e. not present in response from k8s API)