### PR TITLE
Setup CI for end-to-end test and automate docker push

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
+sudo: required
+services:
+  - docker
 language: go
 go:
-    - 1.7.x
-before_install: mkdir $GOPATH/bin && curl https://glide.sh/get | sh
-install: make get-deps
-script: make test-local
+  - 1.7.x
+install:
+  - make get-deps
+script:
+  - make unit
+  - make docker-publish

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,17 @@
+# Copyright 2017 Mirantis
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM busybox
 
 MAINTAINER Artem Roma <aroma@mirantis.com>

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,7 +1,0 @@
-FROM golang:1.7-alpine
-
-MAINTAINER Artem Roma <aroma@mirantis.com>
-
-RUN apk add --update bash
-
-WORKDIR /go/src/github.com/Mirantis/k8s-netchecker-server

--- a/Makefile
+++ b/Makefile
@@ -1,53 +1,157 @@
-BUILD_DIR=_output
-BIN_NAME=server
-UTILITY_IMAGE_NAME=k8s-netchecker-server.build
-RELEASE_IMAGE_NAME?=quay.io/l23network/k8s-netchecker-server
-RELEASE_IMAGE_TAG?=latest
-TARGET_IMAGE=$(RELEASE_IMAGE_NAME):$(RELEASE_IMAGE_TAG)
+# Copyright 2017 Mirantis
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-$(BUILD_DIR):
-	mkdir -p $(BUILD_DIR)
 
-.PHONY: build-local
-build-local: $(BUILD_DIR)
-	go build -o $(BUILD_DIR)/$(BIN_NAME) cmd/server.go
+IMAGE_REPO_SERVER ?= mirantis/k8s-netchecker-server
+IMAGE_REPO_AGENT ?= mirantis/k8s-netchecker-agent
+# repo for biuld agent docker image
+NETCHECKER_REPO ?= k8s-netchecker-agent
+DOCKER_BUILD ?= no
 
-.PHONY: rebuild-local
-rebuild-local: clean build-local
+BUILD_DIR = _output
+VENDOR_DIR = vendor
+ROOT_DIR = $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
+# kubeadm-dind-cluster supports k8s versions:
+# "v1.4", "v1.5" and "v1.6".
+DIND_CLUSTER_VERSION ?= v1.5
+
+ENV_PREPARE_MARKER = .env-prepare.complete
+BUILD_IMAGE_MARKER = .build-image.complete
+
+
+ifeq ($(DOCKER_BUILD), yes)
+	_DOCKER_GOPATH = /go
+	_DOCKER_WORKDIR = $(_DOCKER_GOPATH)/src/github.com/Mirantis/k8s-netchecker-server/
+	_DOCKER_IMAGE  = golang:1.7
+	DOCKER_DEPS = apt-get update; apt-get install -y libpcap-dev;
+	DOCKER_EXEC = docker run --rm -it -v "$(ROOT_DIR):$(_DOCKER_WORKDIR)" \
+		-w "$(_DOCKER_WORKDIR)" $(_DOCKER_IMAGE)
+else
+	DOCKER_EXEC =
+	DOCKER_DEPS =
+endif
+
+
+.PHONY: help
+help:
+	@echo "For containerized "make get-deps""
+	@echo "and "make test" export DOCKER_BUILD=yes"
+	@echo ""
+	@echo "Usage: 'make <target>'"
+	@echo ""
+	@echo "Targets:"
+	@echo "help                - Print this message and exit"
+	@echo "get-deps            - Install project dependencies"
+	@echo "build               - Build k8s-netchecker-server binary"
+	@echo "containerized-build - Build k8s-netchecker-server binary in container"
+	@echo "build-image         - Build docker image"
+	@echo "test                - Run all tests"
+	@echo "unit                - Run unit tests"
+	@echo "e2e                 - Run e2e tests"
+	@echo "docker-publish      - Push images to Docker Hub registry"
+	@echo "clean               - Delete binaries"
+	@echo "clean-k8s           - Delete kubeadm-dind-cluster"
+	@echo "clean-all           - Delete binaries and vendor files"
+
 
 .PHONY: get-deps
-get-deps:
-	glide install --strip-vendor
+get-deps: $(VENDOR_DIR)
 
-.PHONY: test-local
-test-local:
-	go test -v ./pkg/...
+
+.PHONY: build
+build: $(BUILD_DIR)/server
+
+
+.PHONY: containerized-build
+containerized-build:
+	make build DOCKER_BUILD=yes
+
+
+.PHONY: build-image
+build-image: $(BUILD_IMAGE_MARKER)
+
+
+.PHONY: unit
+unit:
+	$(DOCKER_EXEC) go test -v ./pkg/...
+
+
+.PHONY: e2e
+e2e: $(BUILD_DIR)/e2e.test $(ENV_PREPARE_MARKER)
+	echo "TODO: sudo $(BUILD_DIR)/e2e.test"
+
+
+.PHONY: test
+test: unit e2e
+
+
+.PHONY: docker-publish
+docker-publish:
+	IMAGE_REPO=$(IMAGE_REPO_SERVER) bash ./scripts/docker_publish.sh
+
 
 .PHONY: clean
 clean:
 	rm -rf $(BUILD_DIR)
 
+
+.PHONY: clean-k8s
+clean-k8s:
+	bash ./scripts/dind-cluster-$(DIND_CLUSTER_VERSION).sh clean
+	rm -f ./scripts/dind-cluster-$(DIND_CLUSTER_VERSION).sh
+	rm -rf $(HOME)/.kubeadm-dind-cluster
+	rm -rf $(HOME)/.kube
+	rm -f $(ENV_PREPARE_MARKER)
+
+
 .PHONY: clean-all
-clean-all: clean
-	docker rmi $(UTILITY_IMAGE_NAME)
-	docker rmi $(TARGET_IMAGE)
+clean-all: clean clean-k8s
+	rm -rf $(VENDOR_DIR)
+	docker rmi -f $(IMAGE_REPO_SERVER)
+	docker rmi -f $(IMAGE_REPO_AGENT)
+	rm -f $(BUILD_IMAGE_MARKER)
 
-build-utility-image: Dockerfile.build
-	docker build -f Dockerfile.build -t $(UTILITY_IMAGE_NAME) .
 
-go-build-containerized:  $(BUILD_DIR) build-utility-image
-	docker run --rm  \
-		-v $(PWD):/go/src/github.com/Mirantis/k8s-netchecker-server:ro \
-		-v $(PWD)/$(BUILD_DIR):/go/src/github.com/Mirantis/k8s-netchecker-server/$(BUILD_DIR) \
-		-w /go/src/github.com/Mirantis/k8s-netchecker-server/ \
-		$(UTILITY_IMAGE_NAME) bash -c '\
-			CGO_ENABLED=0 go build -x -o $(BUILD_DIR)/$(BIN_NAME) -ldflags "-s -w" cmd/server.go &&\
-			chown -R $(shell id -u):$(shell id -u) $(BUILD_DIR)'
+$(BUILD_DIR):
+	mkdir -p $(BUILD_DIR)
 
-build-release-image: go-build-containerized
-	docker build -t $(TARGET_IMAGE) .
 
-test-containerized: build-utility-image
-	docker run --rm \
-		-v $(PWD):/go/src/github.com/Mirantis/k8s-netchecker-server:ro \
-		$(UTILITY_IMAGE_NAME) go test -v ./pkg/...
+$(VENDOR_DIR):
+	$(DOCKER_EXEC) bash -xc 'go get github.com/Masterminds/glide && \
+		glide install --strip-vendor; \
+		chown $(shell id -u):$(shell id -g) -R $(VENDOR_DIR)'
+
+
+$(BUILD_DIR)/server: $(BUILD_DIR) $(VENDOR_DIR)
+	$(DOCKER_EXEC) bash -xc '$(DOCKER_DEPS) \
+		CGO_ENABLED=0 go build --ldflags "-s -w" \
+		-x -o $@ ./cmd/server.go; \
+		chown $(shell id -u):$(shell id -g) -R $(BUILD_DIR)'
+
+
+$(BUILD_DIR)/e2e.test: $(BUILD_DIR) $(VENDOR_DIR)
+	$(DOCKER_EXEC) echo "TODO: go test -c -o $@ ./test/e2e/"
+
+
+$(BUILD_IMAGE_MARKER): $(BUILD_DIR)/server
+	docker build -t $(IMAGE_REPO_SERVER) .
+	touch $(BUILD_IMAGE_MARKER)
+
+
+$(ENV_PREPARE_MARKER): build-image
+	NETCHECKER_REPO=$(NETCHECKER_REPO) bash ./scripts/build_image_server_or_agent.sh
+	bash ./scripts/kubeadm_dind_cluster.sh
+	IMAGE_REPO_SERVER=$(IMAGE_REPO_SERVER) IMAGE_REPO_AGENT=$(IMAGE_REPO_AGENT) bash ./scripts/import_images.sh
+	touch $(ENV_PREPARE_MARKER)

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -1,3 +1,17 @@
+// Copyright 2017 Mirantis
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/examples/deploy.sh
+++ b/examples/deploy.sh
@@ -1,31 +1,52 @@
 #!/bin/bash
+# Copyright 2017 Mirantis
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # env: NS - a namespace name (also as $1)
 # env: KUBE_DIR - manifests directory, e.g. /etc/kubernetes
 # env: KUBE_USER - a user to own the manifests directory
 # env: NODE_PORT - a node port for the server app to listen on
 # env: PURGE - if true, will only erase applications
 # env: AGENT_REPORT_INTERVAL - an interval for agents to report
-set -e
 
-SERVER_IMAGE_NAME=aateem/k8s-netchecker-server
-SERVER_IMAGE_TAG=golang
-AGENT_IMAGE_NAME=aateem/k8s-netchecker-agent
-AGENT_IMAGE_TAG=golang
+set -o xtrace
+set -o pipefail
+set -o errexit
+set -o nounset
 
-if [ -n "$1" -o -n "${NS}" ] ; then
+
+SERVER_IMAGE_NAME=${SERVER_IMAGE_NAME:-mirantis/k8s-netchecker-server}
+AGENT_IMAGE_NAME=${AGENT_IMAGE_NAME:-mirantis/k8s-netchecker-agent}
+IMAGE_TAG=${IMAGE_TAG:-latest}
+NODE_PORT=${NODE_PORT:-31081}
+KUBE_USER=${KUBE_USER:-}
+KUBE_DIR=${KUBE_DIR:-./}
+
+
+if [ -n "$1" ] || [ -n "${NS}" ]; then
   NS="--namespace=${1:-NS}"
 fi
-NODE_PORT=${NODE_PORT:-31081}
-KUBE_DIR="${KUBE_DIR:-./}"
-if [ "${KUBE_DIR}" != "./" -a -n "${KUBE_USER}" ]; then
-  mkdir -p ${KUBE_DIR}
+
+if [ "${KUBE_DIR}" != "./" ] && [ -n "${KUBE_USER}" ]; then
+  mkdir -p "${KUBE_DIR}"
 fi
 
 # check there are nodes in the cluster
 kubectl get nodes
 
 echo "Installing netchecker server"
-cat << EOF > ${KUBE_DIR}/netchecker-server-pod.yml
+cat << EOF > "${KUBE_DIR}"/netchecker-server-pod.yml
 apiVersion: v1
 kind: Pod
 metadata:
@@ -35,7 +56,7 @@ metadata:
 spec:
   containers:
     - name: netchecker-server
-      image: ${SERVER_IMAGE_NAME}:${SERVER_IMAGE_TAG}
+      image: "${SERVER_IMAGE_NAME}":"${IMAGE_TAG}"
       imagePullPolicy: Always
       ports:
         - containerPort: 8081
@@ -47,7 +68,7 @@ spec:
         - "-endpoint=0.0.0.0:8081"
 EOF
 
-cat << EOF > ${KUBE_DIR}/netchecker-server-svc.yml
+cat << EOF > "${KUBE_DIR}"/netchecker-server-svc.yml
 apiVersion: v1
 kind: "Service"
 metadata:
@@ -60,11 +81,11 @@ spec:
       protocol: TCP
       port: 8081
       targetPort: 8081
-      nodePort: ${NODE_PORT}
+      nodePort: "${NODE_PORT}"
   type: NodePort
 EOF
 
-cat << EOF > ${KUBE_DIR}/netchecker-agent-ds.yml
+cat << EOF > "${KUBE_DIR}"/netchecker-agent-ds.yml
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
@@ -80,7 +101,7 @@ spec:
     spec:
       containers:
         - name: netchecker-agent
-          image: ${AGENT_IMAGE_NAME}:${AGENT_IMAGE_TAG}
+          image: "${AGENT_IMAGE_NAME}":"${IMAGE_TAG}"
           env:
             - name: MY_POD_NAME
               valueFrom:
@@ -94,7 +115,7 @@ spec:
           imagePullPolicy: Always
 EOF
 
-cat << EOF > ${KUBE_DIR}/netchecker-agent-hostnet-ds.yml
+cat << EOF > "${KUBE_DIR}"/netchecker-agent-hostnet-ds.yml
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
@@ -111,7 +132,7 @@ spec:
       hostNetwork: True
       containers:
         - name: netchecker-agent
-          image: ${AGENT_IMAGE_NAME}:${AGENT_IMAGE_TAG}
+          image: "${AGENT_IMAGE_NAME}":"${IMAGE_TAG}"
           env:
             - name: MY_POD_NAME
               valueFrom:
@@ -125,25 +146,25 @@ spec:
           imagePullPolicy: Always
 EOF
 
-if [ "${KUBE_DIR}" != "./" -a -n "${KUBE_USER}" ]; then
-  chown -R ${KUBE_USER}: ${KUBE_DIR}
+if [ "${KUBE_DIR}" != "./" ] && [ -n "${KUBE_USER}" ]; then
+  chown -R "${KUBE_USER}": "${KUBE_DIR}"
 fi
 
-kubectl delete --grace-period=1 -f ${KUBE_DIR}/netchecker-agent-ds.yml $NS || true
-kubectl delete --grace-period=1 -f ${KUBE_DIR}/netchecker-agent-hostnet-ds.yml $NS || true
-kubectl delete --grace-period=1 -f ${KUBE_DIR}/netchecker-server-svc.yml $NS || true
-(kubectl delete --grace-period=1 -f ${KUBE_DIR}/netchecker-server-pod.yml $NS && sleep 10) || true
+kubectl delete --grace-period=1 -f "${KUBE_DIR}"/netchecker-agent-ds.yml "${NS}" || true
+kubectl delete --grace-period=1 -f "${KUBE_DIR}"/netchecker-agent-hostnet-ds.yml "${NS}" || true
+kubectl delete --grace-period=1 -f "${KUBE_DIR}"/netchecker-server-svc.yml "${NS}" || true
+(kubectl delete --grace-period=1 -f "${KUBE_DIR}"/netchecker-server-pod.yml "${NS}" && sleep 10) || true
 
 if [ "${PURGE:-false}" != "true" ]; then
-  kubectl create -f ${KUBE_DIR}/netchecker-server-pod.yml $NS
-  kubectl create -f ${KUBE_DIR}/netchecker-server-svc.yml $NS
-  kubectl create -f ${KUBE_DIR}/netchecker-agent-ds.yml $NS
-  kubectl create -f ${KUBE_DIR}/netchecker-agent-hostnet-ds.yml $NS
+  kubectl create -f "${KUBE_DIR}"/netchecker-server-pod.yml "${NS}"
+  kubectl create -f "${KUBE_DIR}"/netchecker-server-svc.yml "${NS}"
+  kubectl create -f "${KUBE_DIR}"/netchecker-agent-ds.yml "${NS}"
+  kubectl create -f "${KUBE_DIR}"/netchecker-agent-hostnet-ds.yml "${NS}"
 fi
 
 echo "DONE"
-echo "use the following commands to "
+echo "Use the following commands to "
 echo "- check agents responses:"
-echo "curl -s -X GET 'http://localhost:${NODE_PORT}/api/v1/agents/' | python -mjson.tool"
+echo "  curl -s -X GET 'http://localhost:${NODE_PORT}/api/v1/agents/' | python -mjson.tool"
 echo "- check connectivity with agents:"
-echo "curl -X GET 'http://localhost:${NODE_PORT}/api/v1/connectivity_check'"
+echo "  curl -X GET 'http://localhost:${NODE_PORT}/api/v1/connectivity_check'"

--- a/helm-chart/netchecker-server/values.yaml
+++ b/helm-chart/netchecker-server/values.yaml
@@ -2,7 +2,7 @@ app:
   name: netchecker-server
 
 image:
-  repository: quay.io/l23network/k8s-netchecker-server
+  repository: mirantis/k8s-netchecker-server
   tag: latest
   pullPolicy: Always
 

--- a/pkg/utils/data.go
+++ b/pkg/utils/data.go
@@ -1,3 +1,17 @@
+// Copyright 2017 Mirantis
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package utils
 
 import "time"

--- a/pkg/utils/handler.go
+++ b/pkg/utils/handler.go
@@ -1,3 +1,17 @@
+// Copyright 2017 Mirantis
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package utils
 
 import (

--- a/pkg/utils/handler_test.go
+++ b/pkg/utils/handler_test.go
@@ -1,3 +1,17 @@
+// Copyright 2017 Mirantis
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package utils
 
 import (

--- a/pkg/utils/k8s.go
+++ b/pkg/utils/k8s.go
@@ -1,3 +1,17 @@
+// Copyright 2017 Mirantis
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package utils
 
 import (

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,3 +1,17 @@
+// Copyright 2017 Mirantis
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package utils
 
 import (

--- a/scripts/build_image_server_or_agent.sh
+++ b/scripts/build_image_server_or_agent.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Copyright 2017 Mirantis
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o xtrace
+set -o pipefail
+set -o errexit
+set -o nounset
+
+
+NETCHECKER_REPO=${NETCHECKER_REPO:-}
+NETCHECKER_BRANCH=${NETCHECKER_BRANCH:-master}
+
+
+function build-image-server-or-agent {
+  if [ -z "${NETCHECKER_REPO}" ]; then
+  	echo "NETCHECKER_REPO is not set!"
+  	exit 1
+  else
+      pushd "../" &> /dev/null
+      if [ ! -d "${NETCHECKER_REPO}" ]; then
+        git clone --branch "${NETCHECKER_BRANCH}" \
+            --depth 1 --single-branch "https://github.com/Mirantis/${NETCHECKER_REPO}.git"
+      fi
+  fi
+  pushd "./${NETCHECKER_REPO}" &> /dev/null
+  make build-image
+  popd &> /dev/null
+  popd &> /dev/null
+}
+
+build-image-server-or-agent

--- a/scripts/docker_publish.sh
+++ b/scripts/docker_publish.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Copyright 2017 Mirantis
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o xtrace
+set -o pipefail
+set -o errexit
+set -o nounset
+
+
+TRAVIS_PULL_REQUEST_BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-}
+TRAVIS_TEST_RESULT=${TRAVIS_TEST_RESULT:-}
+TRAVIS_BRANCH=${TRAVIS_BRANCH:-}
+IMAGE_REPO=${IMAGE_REPO:-}
+TRAVIS_TAG=${TRAVIS_TAG:-}
+
+
+function push-to-docker {
+  if [ -z "${TRAVIS_TEST_RESULT}" ]; then
+    echo "TRAVIS_TEST_RESULT is not set!"
+    exit 1
+  else
+      if [ "${TRAVIS_TEST_RESULT}" -ne 0 ]; then
+        echo "Some of the previous steps ended with an errors! The build is broken!"
+        exit 1
+      fi
+  fi
+
+  if [ "${TRAVIS_PULL_REQUEST_BRANCH}" != "" ]; then
+    echo "Processing PR ${TRAVIS_PULL_REQUEST_BRANCH}"
+    exit 0
+  else
+      set +o xtrace
+      docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}"
+      set -o xtrace
+  fi
+
+  if [ -z "${IMAGE_REPO}" ]; then
+    echo "IMAGE_REPO is not set!"
+    exit 1
+  fi
+
+  if [ ! -z "${TRAVIS_TAG}" ]; then
+    echo "Pushing with tag - ${TRAVIS_TAG}"
+    docker tag "${IMAGE_REPO}" "${IMAGE_REPO}":"${TRAVIS_TAG}"
+    docker push "${IMAGE_REPO}":"${TRAVIS_TAG}"
+    exit
+  fi
+
+  if [ "${TRAVIS_BRANCH}" == "master" ]; then
+    echo "Pushing with tag - latest"
+    docker push "${IMAGE_REPO}":latest
+    exit
+  fi
+
+  echo "Pushing with tag - ${TRAVIS_BRANCH}"
+  docker tag "${IMAGE_REPO}" "${IMAGE_REPO}":"${TRAVIS_BRANCH}"
+  docker push "${IMAGE_REPO}":"${TRAVIS_BRANCH}"
+}
+
+push-to-docker

--- a/scripts/import_images.sh
+++ b/scripts/import_images.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Copyright 2017 Mirantis
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o xtrace
+set -o pipefail
+set -o errexit
+set -o nounset
+
+
+IMAGE_REPO_SERVER=${IMAGE_REPO_SERVER:-mirantis/k8s-netchecker-server}
+IMAGE_REPO_AGENT=${IMAGE_REPO_AGENT:-mirantis/k8s-netchecker-agent}
+IMAGE_TAG=${IMAGE_TAG:-latest}
+NUM_NODES=${NUM_NODES:-3}
+TMP_IMAGE_PATH=${TMP_IMAGE_PATH:-/tmp/netchecker-all.tar}
+# export MASTER_NAME=kube-master if you need
+# to import images in kube-master node
+MASTER_NAME=${MASTER_NAME:-}
+SLAVE_NAME=${SLAVE_NAME:-"kube-node-"}
+
+
+function import-images {
+	docker save -o "${TMP_IMAGE_PATH}" \
+	"${IMAGE_REPO_SERVER}":"${IMAGE_TAG}" "${IMAGE_REPO_AGENT}":"${IMAGE_TAG}"
+
+    if [ ! -z "${MASTER_NAME}" ]; then
+      docker cp "${TMP_IMAGE_PATH}" "${MASTER_NAME}":/netchecker-all.tar
+      docker exec -ti "${MASTER_NAME}" docker load -i /netchecker-all.tar
+      docker exec -ti "${MASTER_NAME}" docker images
+    fi
+
+    for node in $(seq 1 "${NUM_NODES}"); do
+      docker cp "${TMP_IMAGE_PATH}" "${SLAVE_NAME}""${node}":/netchecker-all.tar
+      docker exec -ti "${SLAVE_NAME}""${node}" docker load -i /netchecker-all.tar
+      docker exec -ti "${SLAVE_NAME}""${node}" docker images
+    done
+    echo "Finished copying docker images to dind nodes"
+}
+
+import-images

--- a/scripts/kubeadm_dind_cluster.sh
+++ b/scripts/kubeadm_dind_cluster.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Copyright 2017 Mirantis
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o xtrace
+set -o pipefail
+set -o errexit
+set -o nounset
+
+
+NUM_NODES=${NUM_NODES:-3}
+KUBEADM_SCRIPT_URL=${KUBEADM_SCRIPT_URL:-https://cdn.rawgit.com/Mirantis/kubeadm-dind-cluster/master/fixed/dind-cluster}
+# kubeadm-dind-cluster supports k8s versions:
+# "v1.4", "v1.5" and "v1.6".
+DIND_CLUSTER_VERSION=${DIND_CLUSTER_VERSION:-v1.5}
+
+
+function kubeadm-dind-cluster {
+  pushd "./scripts" &> /dev/null
+  wget "${KUBEADM_SCRIPT_URL}-${DIND_CLUSTER_VERSION}.sh"
+  chmod +x ./dind-cluster-"${DIND_CLUSTER_VERSION}".sh
+  NUM_NODES="${NUM_NODES}" bash ./dind-cluster-"${DIND_CLUSTER_VERSION}".sh down
+  NUM_NODES="${NUM_NODES}" bash ./dind-cluster-"${DIND_CLUSTER_VERSION}".sh up
+  popd &> /dev/null
+}
+
+kubeadm-dind-cluster


### PR DESCRIPTION
- Automate infrastructure setting up for end-to-end
  tests on Travis CI

- Automate docker image building and publishing for
  network checker projects

- Add copyright notices

- Setup helm-chart at new images

- Setup deploy.sh at new images

Fixes #37