### PR TITLE
Node name to metrics

### DIFF
--- a/examples/deploy.sh
+++ b/examples/deploy.sh
@@ -102,6 +102,10 @@ spec:
         - name: netchecker-agent
           image: ${AGENT_IMAGE_NAME}:${IMAGE_TAG}
           env:
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             - name: MY_POD_NAME
               valueFrom:
                 fieldRef:
@@ -133,6 +137,10 @@ spec:
         - name: netchecker-agent
           image: ${AGENT_IMAGE_NAME}:${IMAGE_TAG}
           env:
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             - name: MY_POD_NAME
               valueFrom:
                 fieldRef:

--- a/examples/pod.yml
+++ b/examples/pod.yml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
     - name: netchecker-server
-      image: 127.0.0.1:31500/netchecker/server:latest
+      image: mirantis/k8s-netchecker-server:latest
       imagePullPolicy: Always
       ports:
         - containerPort: 8081

--- a/pkg/extensions/types.go
+++ b/pkg/extensions/types.go
@@ -56,18 +56,17 @@ type AgentSpec struct {
 
 type Agent struct {
 	meta_v1.TypeMeta `json:",inline"`
-	Metadata meta_v1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	Metadata         meta_v1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	Spec AgentSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 }
 
 type AgentList struct {
 	meta_v1.TypeMeta `json:",inline"`
-	Metadata meta_v1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	Metadata         meta_v1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	Items []Agent `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
-
 
 func (e *Agent) GetObjectKind() schema.ObjectKind {
 	return &e.TypeMeta
@@ -85,16 +84,14 @@ func (el *AgentList) GetListMeta() meta_v1.List {
 	return &el.Metadata
 }
 
-
 type AgentCopy Agent
 type AgentListCopy AgentList
-
 
 func (e *Agent) UnmarshalJSON(data []byte) error {
 	tmp := AgentCopy{}
 	err := json.Unmarshal(data, &tmp)
 	if err != nil {
-			return err
+		return err
 	}
 	tmp2 := Agent(tmp)
 	*e = tmp2
@@ -105,7 +102,7 @@ func (el *AgentList) UnmarshalJSON(data []byte) error {
 	tmp := AgentListCopy{}
 	err := json.Unmarshal(data, &tmp)
 	if err != nil {
-			return err
+		return err
 	}
 	tmp2 := AgentList(tmp)
 	*el = tmp2

--- a/pkg/utils/handler.go
+++ b/pkg/utils/handler.go
@@ -40,10 +40,10 @@ func NewHandler(createKubeClient bool) (*Handler, error) {
 
 	var err error
 	if createKubeClient {
-		kProxy := &KubeProxy{}
-		err = kProxy.SetupClientSet()
+		proxy := &KubeProxy{}
+		err = proxy.SetupClientSet()
 		if err == nil {
-			h.KubeClient = kProxy
+			h.KubeClient = proxy
 		}
 		err = kProxy.initThirdParty()
 		if err != nil {
@@ -84,12 +84,12 @@ func (h *Handler) UpdateAgents(rw http.ResponseWriter, r *http.Request, rp httpr
 
 	agentData.LastUpdated = time.Now()
 	glog.V(10).Infof("Updating the agents cache with value: %v", agentData)
-	agent_name := rp.ByName("name")
-	if _, exists := h.AgentCache[agent_name]; !exists {
-		h.Metrics[agent_name] = NewAgentMetrics(&agentData)
+	agentName := rp.ByName("name")
+	if _, exists := h.AgentCache[agentName]; !exists {
+		h.Metrics[agentName] = NewAgentMetrics(&agentData)
 	}
-	UpdateAgentMetrics(h.Metrics[agent_name], true, false)
-	h.AgentCache[agent_name] = agentData
+	UpdateAgentMetrics(h.Metrics[agentName], true, false)
+	h.AgentCache[agentName] = agentData
 }
 
 func (h *Handler) GetAgents(rw http.ResponseWriter, r *http.Request, _ httprouter.Params) {
@@ -195,7 +195,7 @@ func (h *Handler) CleanCache(handle httprouter.Handle) httprouter.Handle {
 				podMap[pod.ObjectMeta.Name] = empty{}
 			}
 
-			for agentName, _ := range h.AgentCache {
+			for agentName := range h.AgentCache {
 				if _, exists := podMap[agentName]; !exists {
 					toRemove = append(toRemove, agentName)
 				}
@@ -214,7 +214,7 @@ func (h *Handler) CleanCache(handle httprouter.Handle) httprouter.Handle {
 func (h *Handler) CollectAgentsMetrics() {
 	for {
 		time.Sleep(5 * time.Second)
-		for name, _ := range h.AgentCache {
+		for name := range h.AgentCache {
 			if _, exists := h.Metrics[name]; exists {
 				deltaInIntervals := time.Now().Sub(h.AgentCache[name].LastUpdated).Seconds() /
 					float64(h.AgentCache[name].ReportInterval)

--- a/pkg/utils/handler.go
+++ b/pkg/utils/handler.go
@@ -45,7 +45,7 @@ func NewHandler(createKubeClient bool) (*Handler, error) {
 		if err == nil {
 			h.KubeClient = proxy
 		}
-		err = kProxy.initThirdParty()
+		err = proxy.initThirdParty()
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/utils/handler.go
+++ b/pkg/utils/handler.go
@@ -217,7 +217,7 @@ func (h *Handler) CollectAgentsMetrics() {
 		for name, _ := range h.AgentCache {
 			if _, exists := h.Metrics[name]; exists {
 				deltaInIntervals := time.Now().Sub(h.AgentCache[name].LastUpdated).Seconds() /
-						float64(h.AgentCache[name].ReportInterval)
+					float64(h.AgentCache[name].ReportInterval)
 				if int(deltaInIntervals) > (h.Metrics[name].ErrorsFromLastReport + 1) {
 					UpdateAgentMetrics(h.Metrics[name], false, true)
 				}

--- a/pkg/utils/handler_test.go
+++ b/pkg/utils/handler_test.go
@@ -413,7 +413,7 @@ func TestConnectivityCheckFailDueError(t *testing.T) {
 	failMsg := fmt.Sprintf(
 		"Failed to get pods from k8s cluster. Details: test error\n")
 
-	if actual != failMsg {
+	if !strings.Contains(actual, failMsg) {
 		t.Errorf(
 			"Unexpected message from bad request result payload. Actual: %v",
 			actual)

--- a/pkg/utils/k8s.go
+++ b/pkg/utils/k8s.go
@@ -17,13 +17,13 @@ package utils
 import (
 	"github.com/golang/glog"
 
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
 
@@ -39,7 +39,6 @@ type KubeProxy struct {
 	Client kubernetes.Interface
 }
 
-
 func (kp *KubeProxy) SetupClientSet() error {
 	config, err := rest.InClusterConfig()
 	if err != nil {
@@ -54,7 +53,6 @@ func (kp *KubeProxy) SetupClientSet() error {
 	kp.Client = clientSet
 	return nil
 }
-
 
 func (kp *KubeProxy) initThirdParty() error {
 	tpr, err := kp.Client.ExtensionsV1beta1().ThirdPartyResources().Get("agent.network-checker.ext", meta_v1.GetOptions{})
@@ -83,7 +81,6 @@ func (kp *KubeProxy) initThirdParty() error {
 
 	return err
 }
-
 
 func (kp *KubeProxy) Pods() (*v1.PodList, error) {
 	requirement, err := labels.NewRequirement(AgentLabelKey, selection.In, AgentLabelValues)

--- a/pkg/utils/metrics.go
+++ b/pkg/utils/metrics.go
@@ -66,10 +66,9 @@ func tryRegister(m prometheus.Counter) (prometheus.Counter, bool) {
 			existing := are.ExistingCollector.(prometheus.Counter)
 			glog.V(5).Infof("Counter %v has been registered already.", existing.Desc())
 			return existing, false
-		} else {
-			// Something else went wrong!
-			panic(err)
 		}
+		// Something else went wrong!
+		panic(err)
 	}
 	return m, true
 }

--- a/pkg/utils/metrics.go
+++ b/pkg/utils/metrics.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/golang/glog"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -44,9 +45,33 @@ func NewAgentMetrics(ai *AgentInfo) AgentMetrics {
 		Help:        "Total number of reports (keepalive messages) from the agent.",
 	})
 
-	prometheus.MustRegister(am.ErrorCount)
-	prometheus.MustRegister(am.ReportCount)
+	if counter, ok := tryRegister(am.ErrorCount); !ok {
+		// use existing counter
+		am.ErrorCount = counter
+	}
+	if counter, ok := tryRegister(am.ReportCount); !ok {
+		// use existing counter
+		am.ReportCount = counter
+	}
+
 	return am
+}
+
+// returns true if registering went fine, false if counter was registered already,
+// panics on other register errors
+func tryRegister(m prometheus.Counter) (prometheus.Counter, bool) {
+	if err := prometheus.Register(m); err != nil {
+		if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			// A counter for that metric has been registered before.
+			existing := are.ExistingCollector.(prometheus.Counter)
+			glog.V(5).Infof("Counter %v has been registered already.", existing.Desc())
+			return existing, false
+		} else {
+			// Something else went wrong!
+			panic(err)
+		}
+	}
+	return m, true
 }
 
 func UpdateAgentMetrics(am AgentMetrics, report, error bool) {

--- a/pkg/utils/metrics.go
+++ b/pkg/utils/metrics.go
@@ -30,8 +30,7 @@ func NewAgentMetrics(ai *AgentInfo) AgentMetrics {
 	if strings.Contains(ai.PodName, "hostnet") {
 		suffix = "host_network"
 	}
-	name_splitted := strings.Split(ai.PodName, "-")
-	name := name_splitted[len(name_splitted)-1]
+	name := ai.NodeName
 	am.ErrorCount = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace:   "ncagent",
 		Name:        "error_count_total",


### PR DESCRIPTION
Node names of agents (instead of agent pod hashes) are now shown in metrics labels.

Closes: https://github.com/Mirantis/k8s-netchecker-server/issues/82

Fixed some codeclimate comments:

Closes: https://github.com/Mirantis/k8s-netchecker-server/issues/44
Closes: https://github.com/Mirantis/k8s-netchecker-server/issues/59

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/k8s-netchecker-server/88)
<!-- Reviewable:end -->
