### PR TITLE
Change guard interval for agent failure detection

### DIFF
--- a/pkg/utils/handler.go
+++ b/pkg/utils/handler.go
@@ -168,7 +168,7 @@ func (h *Handler) CheckAgents() ([]string, []string, error) {
 		}
 
 		delta := time.Now().Sub(agentData.LastUpdated).Seconds()
-		if delta > float64(agentData.ReportInterval) {
+		if delta > float64(agentData.ReportInterval*2) {
 			outdated = append(outdated, agentName)
 		}
 	}

--- a/pkg/utils/handler_test.go
+++ b/pkg/utils/handler_test.go
@@ -368,7 +368,7 @@ func TestConnectivityCheckFail(t *testing.T) {
 	agent.PodName = "agent-pod-hostnet"
 	//back to the past
 	agent.LastUpdated = agent.HostDate.Add(
-		-time.Second * time.Duration(agent.ReportInterval+1))
+		-time.Second * time.Duration(agent.ReportInterval*2+1))
 
 	handler.AgentCache[agent.PodName] = agent
 


### PR DESCRIPTION
Now agent failure is reported when there was no keepalive message
from the agent for more than 2*report_interval time.

Closes: https://github.com/Mirantis/k8s-netchecker-server/issues/87

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/k8s-netchecker-server/91)
<!-- Reviewable:end -->
