### PR TITLE
Add network probe results recognition

### DIFF
--- a/pkg/utils/data.go
+++ b/pkg/utils/data.go
@@ -34,7 +34,8 @@ type AgentInfo struct {
 
 // ProbeResult structure for network probing results
 type ProbeResult struct {
-	EndPoint         string
+	URL              string
+	Result           int
 	Total            int
 	ContentTransfer  int
 	TCPConnection    int

--- a/pkg/utils/data.go
+++ b/pkg/utils/data.go
@@ -35,7 +35,8 @@ type AgentInfo struct {
 // ProbeResult structure for network probing results
 type ProbeResult struct {
 	URL              string
-	Result           int
+	ConnectionResult int
+	HTTPCode         int
 	Total            int
 	ContentTransfer  int
 	TCPConnection    int

--- a/pkg/utils/data.go
+++ b/pkg/utils/data.go
@@ -28,7 +28,19 @@ type AgentInfo struct {
 	HostDate       time.Time           `json:"hostdate"`
 	LastUpdated    time.Time           `json:"last_updated"`
 	LookupHost     map[string][]string `json:"nslookup"`
+	NetworkProbes  []ProbeResult       `json:"network_probes"`
 	IPs            map[string][]string `json:"ips"`
+}
+
+// ProbeResult structure for network probing results
+type ProbeResult struct {
+	EndPoint         string
+	Total            int
+	ContentTransfer  int
+	TCPConnection    int
+	DNSLookup        int
+	Connect          int
+	ServerProcessing int
 }
 
 // CheckConnectivityInfo is payload structure for server answer to connectivity

--- a/pkg/utils/handler.go
+++ b/pkg/utils/handler.go
@@ -64,6 +64,8 @@ func (h *Handler) SetupRouter() {
 	router.GET("/api/v1/agents/:name", h.CleanCache(h.GetSingleAgent))
 	router.GET("/api/v1/agents/", h.CleanCache(h.GetAgents))
 	router.GET("/api/v1/connectivity_check", h.CleanCache(h.ConnectivityCheck))
+	router.GET("/api/v1/ping", func(_ http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
+	})
 	router.Handler("GET", "/metrics", promhttp.Handler())
 	h.HTTPHandler = router
 }

--- a/pkg/utils/handler_test.go
+++ b/pkg/utils/handler_test.go
@@ -47,6 +47,7 @@ func agentExample() AgentInfo {
 		NodeName:       "test-node",
 		PodName:        "test",
 		HostDate:       time.Now(),
+		NetworkProbes:  []ProbeResult{{"0.0.0.0:8081", 50, 1, 0, 0, 0, 0}},
 	}
 }
 

--- a/pkg/utils/handler_test.go
+++ b/pkg/utils/handler_test.go
@@ -47,7 +47,7 @@ func agentExample() AgentInfo {
 		NodeName:       "test-node",
 		PodName:        "test",
 		HostDate:       time.Now(),
-		NetworkProbes:  []ProbeResult{{"0.0.0.0:8081", 50, 1, 0, 0, 0, 0}},
+		NetworkProbes:  []ProbeResult{{"http://0.0.0.0:8081", 1, 50, 1, 0, 0, 0, 0}},
 	}
 }
 

--- a/pkg/utils/handler_test.go
+++ b/pkg/utils/handler_test.go
@@ -47,7 +47,7 @@ func agentExample() AgentInfo {
 		NodeName:       "test-node",
 		PodName:        "test",
 		HostDate:       time.Now(),
-		NetworkProbes:  []ProbeResult{{"http://0.0.0.0:8081", 1, 50, 1, 0, 0, 0, 0}},
+		NetworkProbes:  []ProbeResult{{"http://0.0.0.0:8081", 1, 200, 50, 1, 0, 0, 0, 0}},
 	}
 }
 


### PR DESCRIPTION
Now server recognizes network probe results from agent keep-alive message. This data is now the part of agents information that is provided on `/api/v1/agents/` request. It can be used to provide corresponding metrics.

Related: https://github.com/Mirantis/k8s-netchecker-agent/issues/11

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/k8s-netchecker-server/93)
<!-- Reviewable:end -->
