### PR TITLE
Complete the basic e2e test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,6 +146,7 @@ $(BUILD_DIR)/server: $(BUILD_DIR) $(VENDOR_DIR)
 		chown $(shell id -u):$(shell id -g) -R $(BUILD_DIR)'
 
 
+
 $(BUILD_DIR)/e2e.test: $(BUILD_DIR) $(VENDOR_DIR)
 	$(DOCKER_EXEC) bash -xc '$(DOCKER_DEPS) \
 		go test -c -o $@ ./test/e2e/'
@@ -160,5 +161,5 @@ $(ENV_PREPARE_MARKER): build-image
 	NETCHECKER_REPO=$(NETCHECKER_REPO) bash ./scripts/build_image_server_or_agent.sh
 	bash ./scripts/kubeadm_dind_cluster.sh
 	IMAGE_REPO_SERVER=$(IMAGE_REPO_SERVER) IMAGE_REPO_AGENT=$(IMAGE_REPO_AGENT) bash ./scripts/import_images.sh
-	NETCHECKER_REPO=$(NETCHECKER_REPO) bash ./scripts/helm_install_and_deploy.sh
+	# NETCHECKER_REPO=$(NETCHECKER_REPO) bash ./scripts/helm_install_and_deploy.sh
 	touch $(ENV_PREPARE_MARKER)

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -232,15 +232,10 @@ func httpServiceGet(port int, ip string, uri string, dst interface{}) {
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			return err
-		} else {
-			resp.Body.Close()
 		}
+		resp.Body.Close()
 		err = json.Unmarshal(body, dst)
-		if err != nil {
-			return err
-		}
-
-		return nil
+		return err
 	}, 10*time.Second, 1*time.Second).Should(gomega.BeNil())
 }
 


### PR DESCRIPTION
Now we have e2e test that checks agents data on server
and connectivity check results in normal conditions
(when there is no connectivity issues in cluster).

Helm deployment is switched off for tests as tests cannot
control net-checker deployment configuration when helm is in use.

Closes: https://github.com/Mirantis/k8s-netchecker-server/issues/81

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/k8s-netchecker-server/100)
<!-- Reviewable:end -->
