### PR TITLE
Fix deployment examples

### DIFF
--- a/examples/deploy.sh
+++ b/examples/deploy.sh
@@ -34,7 +34,7 @@ NODE_PORT=${NODE_PORT:-31081}
 PURGE=${PURGE:-false}
 SERVER_IMAGE_NAME=${SERVER_IMAGE_NAME:-mirantis/k8s-netchecker-server}
 AGENT_IMAGE_NAME=${AGENT_IMAGE_NAME:-mirantis/k8s-netchecker-agent}
-IMAGE_TAG=${IMAGE_TAG:-latest}
+IMAGE_TAG=${IMAGE_TAG:-stable}
 SERVER_IMAGE_TAG=${SERVER_IMAGE_TAG:-$IMAGE_TAG}
 AGENT_IMAGE_TAG=${AGENT_IMAGE_TAG:-$IMAGE_TAG}
 SERVER_PORT=${SERVER_PORT:-8081}
@@ -58,8 +58,8 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io/scrape: true
-        prometheus.io/port: ${SERVER_PORT}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "${SERVER_PORT}"
       name: netchecker-server
       labels:
         app: netchecker-server

--- a/examples/deployment.yml
+++ b/examples/deployment.yml
@@ -7,8 +7,8 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io/scrape: true
-        prometheus.io/port: 8081
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8081"
       name: netchecker-server
       labels:
         app: netchecker-server
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: netchecker-server
-          image: mirantis/k8s-netchecker-server:latest
+          image: mirantis/k8s-netchecker-server:stable
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8081

--- a/examples/deployment.yml
+++ b/examples/deployment.yml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: netchecker-server
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: true
+        prometheus.io/port: 8081
+      name: netchecker-server
+      labels:
+        app: netchecker-server
+      namespace: default
+    spec:
+      containers:
+        - name: netchecker-server
+          image: mirantis/k8s-netchecker-server:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8081
+          args:
+            - "-v=5"
+            - "-logtostderr"
+            - "-kubeproxyinit"
+            - "-endpoint=0.0.0.0:8081"

--- a/examples/pod.yml
+++ b/examples/pod.yml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
     - name: netchecker-server
-      image: mirantis/k8s-netchecker-server:latest
+      image: mirantis/k8s-netchecker-server:stable
       imagePullPolicy: Always
       ports:
         - containerPort: 8081


### PR DESCRIPTION
- server is deployed using Deployment (it was a Pod previously)
- server has annotations to enable Prometheus scraping
- RollingUpdate strategy is now in use for both server and agents
- imagePullPolicy is now "IfNotPresent" for both server and agents
- added SERVER_PORT variable
- "stable" image tag is used by default

Closes: https://github.com/Mirantis/k8s-netchecker-server/issues/86

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/k8s-netchecker-server/105)
<!-- Reviewable:end -->
