### PR TITLE
Add support of using SSL certificates for etcd connection

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -33,12 +33,14 @@ func main() {
 
 	config := utils.GetOrCreateConfig()
 
-	flag.StringVar(&config.HttpListen, "endpoint", "0.0.0.0:8081", "End point (IP address, port) for server to listen on")
-	flag.BoolVar(&config.UseKubeClient, "kubeproxyinit", false, "Control initialization kubernetes client set for connectivity check")
-	flag.IntVar(&repTTL, "report-ttl", 300, "TTL for report results store into ETCD (sec)")
-	flag.IntVar(&pingTimeout, "ping-timeout", 5, "Timeout for ping ETCD server (sec)")
-	flag.StringVar(&config.EtcdEndpoints, "etcd-endpoints", "", "Etcd endpoints list for store states into etcd instead k8s 3d-party resources")
-	flag.StringVar(&config.EtcdTree, "etcd-tree", "netchecker", "Root of tree into Etcd")
+	flag.StringVar(&config.HttpListen, "endpoint", "0.0.0.0:8081", "Endpoint (IP address, port) for server to listen on")
+	flag.BoolVar(&config.UseKubeClient, "kubeproxyinit", false, "use k8s TPR (true) or Etcd (false) as a data storage")
+	flag.IntVar(&repTTL, "report-ttl", 300, "TTL for agents reports data stored in Etcd (sec)")
+	flag.IntVar(&pingTimeout, "ping-timeout", 5, "Etcd server ping timeout (sec)")
+	flag.StringVar(&config.EtcdEndpoints, "etcd-endpoints", "", "Etcd server endpoints list")
+	flag.StringVar(&config.EtcdTree, "etcd-tree", "netchecker", "Root of Etcd tree")
+	flag.StringVar(&config.EtcdKeyFile, "etcd-key", "", "SSL key file when using HTTPS to connect to etcd")
+	flag.StringVar(&config.EtcdCertFile, "etcd-cert", "", "SSL certificate file when using HTTPS to connect to etcd")
 	flag.Parse()
 	glog.Infof("K8s netchecker. Compiled at: %s", version)
 

--- a/pkg/utils/config.go
+++ b/pkg/utils/config.go
@@ -23,17 +23,16 @@ import (
 )
 
 type AppConfig struct {
-	sync.Mutex                  // extend for ensures atomic writes; protects the following fields
-	configured    bool          // flag whether App configured
+	sync.Mutex                  // ensures atomic writes; protects the following fields
 	UseKubeClient bool          // use k8s TPR (true) or etcd (false) as a data storage
 	EtcdEndpoints string        // endpoints (IPaddress1:PORT1[,IPaddress2:PORT2]) of etcd server
 	                            // when etcd is being used as a data storage
 	EtcdTree      string        // Root of NetChecker server etcd tree
 	EtcdCertFile  string        // SSL certificate file when using HTTPS to connect to etcd
 	EtcdKeyFile   string        // SSL key file when using HTTPS to connect to etcd
-	HttpListen    string        // endpoint (IPaddress:PORT) for REST API handlers
-	PingTimeout   time.Duration // Timeout for ping (to etcd) operations
-	ReportTTL     time.Duration // TTL for Agent report
+	HttpListen    string        // REST API endpoint (IPaddress:PORT) for netchecker server to listen to
+	PingTimeout   time.Duration // etcd ping timeout (sec)
+	ReportTTL     time.Duration // TTL for Agent report data when etcd is in use (sec)
 }
 
 var main_config *AppConfig

--- a/pkg/utils/config.go
+++ b/pkg/utils/config.go
@@ -25,10 +25,13 @@ import (
 type AppConfig struct {
 	sync.Mutex                  // extend for ensures atomic writes; protects the following fields
 	configured    bool          // flag whether App configured
-	UseKubeClient bool          //
-	EtcdEndpoints string        // how to connect to etcd
-	EtcdTree      string        // Root of NetChecker tree into etcd
-	HttpListen    string        // IPaddress:PORT for HTTP control API responder
+	UseKubeClient bool          // use k8s TPR (true) or etcd (false) as a data storage
+	EtcdEndpoints string        // endpoints (IPaddress1:PORT1[,IPaddress2:PORT2]) of etcd server
+	                            // when etcd is being used as a data storage
+	EtcdTree      string        // Root of NetChecker server etcd tree
+	EtcdCertFile  string        // SSL certificate file when using HTTPS to connect to etcd
+	EtcdKeyFile   string        // SSL key file when using HTTPS to connect to etcd
+	HttpListen    string        // endpoint (IPaddress:PORT) for REST API handlers
 	PingTimeout   time.Duration // Timeout for ping (to etcd) operations
 	ReportTTL     time.Duration // TTL for Agent report
 }

--- a/pkg/utils/handler.go
+++ b/pkg/utils/handler.go
@@ -134,10 +134,11 @@ func (h *Handler) CleanCache(handle httprouter.Handle) httprouter.Handle {
 func (h *Handler) CollectAgentsMetrics() {
 	for {
 		time.Sleep(5 * time.Second)
-		for name := range h.Agents.AgentCache() {
+		agentsData := h.Agents.AgentCache()
+		for name := range agentsData {
 			if _, exists := h.Metrics[name]; exists {
-				deltaInIntervals := time.Now().Sub(h.Agents.AgentCache()[name].LastUpdated).Seconds() /
-					float64(h.Agents.AgentCache()[name].ReportInterval)
+				deltaInIntervals := time.Now().Sub(agentsData[name].LastUpdated).Seconds() /
+					float64(agentsData[name].ReportInterval)
 				if int(deltaInIntervals) > (h.Metrics[name].ErrorsFromLastReport + 1) {
 					UpdateAgentBaseMetrics(h.Metrics[name], false, true)
 				}

--- a/pkg/utils/metrics.go
+++ b/pkg/utils/metrics.go
@@ -132,7 +132,7 @@ func NewAgentMetrics(ai *ext_v1.AgentSpec) AgentMetrics {
 				params.Field(i).Set(reflect.ValueOf(exists))
 			}
 		} else {
-			glog.V(5).Infof("Skipping %v since it's not prometheus metric.", params.Type().Field(i).Name)
+			glog.V(10).Infof("Skipping %v since it's not prometheus metric.", params.Type().Field(i).Name)
 		}
 	}
 
@@ -146,7 +146,7 @@ func tryRegisterCounter(m prometheus.Counter) (prometheus.Counter, bool) {
 		if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
 			// A counter for that metric has been registered before.
 			existing := are.ExistingCollector.(prometheus.Counter)
-			glog.V(5).Infof("Counter %v has been registered already.", existing.Desc())
+			glog.V(10).Infof("Counter %v has been registered already.", existing.Desc())
 			return existing, false
 		}
 		// Something else went wrong!

--- a/pkg/utils/storer_etcd.go
+++ b/pkg/utils/storer_etcd.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	ext_v1 "github.com/Mirantis/k8s-netchecker-server/pkg/extensions/apis/v1"
-	ext_client "github.com/Mirantis/k8s-netchecker-server/pkg/extensions/client"
 
 	etcd "github.com/coreos/etcd/client"
 	"github.com/golang/glog"
@@ -39,11 +38,10 @@ type EtcdConfig struct {
 
 type K8sConnection struct {
 	KubeClient          Proxy
-	ExtensionsClientset ext_client.Clientset
 }
 
 type EtcdAgentStorage struct {
-	sync.Mutex   // extend for ensures atomic writes; protects the following fields
+	sync.Mutex   // ensures atomic writes; protects the following fields
 	config       *AppConfig
 	etcd         EtcdConfig
 	k8s          K8sConnection
@@ -54,14 +52,14 @@ func NewEtcdStorer() (*EtcdAgentStorage, error) {
 	var err error
 
 	cfg := GetOrCreateConfig()
-	glog.Infof("Endpoints '%s' will be used for connect to etcd.", cfg.EtcdEndpoints)
+	glog.Infof("Endpoints '%s' will be used to connect to etcd.", cfg.EtcdEndpoints)
 
 	rv := &EtcdAgentStorage{
 		NcAgentCache: NcAgentCache{},
 		config:       cfg,
 	}
 
-	// setup http/https transport, compatible with self-signed certs
+	// setup http/https transport compatible with self-signed certs
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: true,
 	}
@@ -98,7 +96,7 @@ func NewEtcdStorer() (*EtcdAgentStorage, error) {
 	}
 
 	// Configure connection to k8s API
-	rv.k8s.KubeClient, rv.k8s.ExtensionsClientset, err = connect2k8s()
+	rv.k8s.KubeClient, _, err = connect2k8s(false)
 
 	return rv, err
 }
@@ -107,13 +105,13 @@ func (s *EtcdAgentStorage) PingETCD() error {
 	var rv error
 	ctx, cancel := context.WithTimeout(context.Background(), s.config.PingTimeout)
 	defer cancel()
-	// set a new key, ignoring it's previous state
+	// set a new key ignoring its previous state
 	_, err := s.etcd.kAPI.Set(ctx, fmt.Sprintf("%s/ping", s.config.EtcdTree), "pong", nil)
 	if err != nil {
 		if err == context.DeadlineExceeded {
-			rv = fmt.Errorf("Ping has no answer more than %d seconds", s.config.PingTimeout)
+			rv = fmt.Errorf("Etcd ping timeout (no answer for %d seconds)", s.config.PingTimeout)
 		} else {
-			rv = fmt.Errorf("Ping to etcd failed: %v", err.Error())
+			rv = fmt.Errorf("Etcd ping failed: %v", err.Error())
 		}
 	}
 	return rv
@@ -149,9 +147,9 @@ func (s *EtcdAgentStorage) createOrUpdateAgentTree(ctx context.Context, dirName 
 		TTL:       s.config.ReportTTL,
 	})
 	if err != nil {
-		glog.Errorf("Updating DIR '%s' failed: %v", dirName, err)
+		glog.Errorf("Directory '%s' update failed: %v", dirName, err)
 	} else {
-		glog.Infof("DIR '%s' %sd successfully", dirName, oper)
+		glog.Infof("Directory '%s' %sd successfully", dirName, oper)
 	}
 }
 
@@ -221,6 +219,7 @@ func (s *EtcdAgentStorage) getAgents() NcAgentCache {
 
 	agentsData = NcAgentCache{}
 	dirName = fmt.Sprintf("%s/agents", s.config.EtcdTree)
+	glog.V(5).Infof("Get agents data from etcd tree '%s'", dirName)
 
 	ctx := context.Background()
 	resp, err := s.etcd.kAPI.Get(ctx, dirName, &etcd.GetOptions{Quorum: true, Recursive: true})
@@ -246,7 +245,7 @@ func (s *EtcdAgentStorage) getAgents() NcAgentCache {
 		}
 		if max_AgentSpec.Uptime > 0 {
 			agentsData[nname] = max_AgentSpec
-			glog.Infof("%s: %#v", nname, last_AgentSpec)
+			glog.V(10).Infof("%s: %#v", nname, last_AgentSpec)
 		}
 	}
 	return agentsData

--- a/pkg/utils/storer_etcd.go
+++ b/pkg/utils/storer_etcd.go
@@ -65,6 +65,16 @@ func NewEtcdStorer() (*EtcdAgentStorage, error) {
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: true,
 	}
+	if (cfg.EtcdKeyFile != "") && (cfg.EtcdCertFile != "") {
+		cert, err := tls.LoadX509KeyPair(cfg.EtcdCertFile, cfg.EtcdKeyFile)
+		if err != nil {
+			glog.Fatalf("Error loading X509 key pair: %s", err)
+		}
+		tlsConfig = &tls.Config{
+			Certificates: []tls.Certificate{cert},
+			InsecureSkipVerify: true,
+		}
+	}
 
 	httpsTransport := &http.Transport{
 		TLSHandshakeTimeout: 10 * time.Second,
@@ -82,6 +92,7 @@ func NewEtcdStorer() (*EtcdAgentStorage, error) {
 	}
 	rv.etcd.kAPI = etcd.NewKeysAPI(rv.etcd.client)
 
+	// Check etcd is accessible
 	if err = rv.PingETCD(); err != nil {
 		return nil, err
 	}

--- a/pkg/utils/storer_k8s.go
+++ b/pkg/utils/storer_k8s.go
@@ -35,7 +35,7 @@ type k8sAgentStorage struct {
 	ExtensionsClientset ext_client.Clientset
 }
 
-func connect2k8s() (Proxy, ext_client.Clientset, error) {
+func connect2k8s(createTPR bool) (Proxy, ext_client.Clientset, error) {
 	var err error
 	var clientset *kubernetes.Clientset
 
@@ -51,6 +51,10 @@ func connect2k8s() (Proxy, ext_client.Clientset, error) {
 	if err != nil {
 		glog.Error(err)
 		return nil, nil, err
+	}
+
+	if !createTPR {
+		return proxy, nil, err
 	}
 
 	err = ext_client.CreateAgentThirdPartyResource(clientset)
@@ -75,7 +79,7 @@ func NewK8sStorer() (*k8sAgentStorage, error) {
 		NcAgentCache: map[string]ext_v1.AgentSpec{},
 	}
 
-	rv.KubeClient, rv.ExtensionsClientset, err = connect2k8s()
+	rv.KubeClient, rv.ExtensionsClientset, err = connect2k8s(true)
 
 	return rv, err
 }


### PR DESCRIPTION
In order to support SSL for etcd connection, ability of using SSL certificates was added.

Related issue: https://github.com/Mirantis/k8s-netchecker-server/issues/80
Related pull: https://github.com/Mirantis/k8s-netchecker-server/pull/111