### PR TITLE
Add support to provide CA file when using etcd with SSL connection

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -41,7 +41,7 @@ func main() {
 	flag.StringVar(&config.EtcdTree, "etcd-tree", "netchecker", "Root of Etcd tree")
 	flag.StringVar(&config.EtcdKeyFile, "etcd-key", "", "SSL key file when using HTTPS to connect to etcd")
 	flag.StringVar(&config.EtcdCertFile, "etcd-cert", "", "SSL certificate file when using HTTPS to connect to etcd")
-	flag.StringVar(&config.EtcdCAFile, "etcd-ca", "", "SSL certificate file when using HTTPS to connect to etcd")
+	flag.StringVar(&config.EtcdCAFile, "etcd-ca", "", "SSL CA file when using HTTPS to connect to etcd")
 	flag.Parse()
 	glog.Infof("K8s netchecker. Compiled at: %s", version)
 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -41,6 +41,7 @@ func main() {
 	flag.StringVar(&config.EtcdTree, "etcd-tree", "netchecker", "Root of Etcd tree")
 	flag.StringVar(&config.EtcdKeyFile, "etcd-key", "", "SSL key file when using HTTPS to connect to etcd")
 	flag.StringVar(&config.EtcdCertFile, "etcd-cert", "", "SSL certificate file when using HTTPS to connect to etcd")
+	flag.StringVar(&config.EtcdCAFile, "etcd-ca", "", "SSL certificate file when using HTTPS to connect to etcd")
 	flag.Parse()
 	glog.Infof("K8s netchecker. Compiled at: %s", version)
 

--- a/pkg/utils/config.go
+++ b/pkg/utils/config.go
@@ -30,6 +30,7 @@ type AppConfig struct {
 	EtcdTree      string        // Root of NetChecker server etcd tree
 	EtcdCertFile  string        // SSL certificate file when using HTTPS to connect to etcd
 	EtcdKeyFile   string        // SSL key file when using HTTPS to connect to etcd
+	EtcdCAFile    string        // SSL CA file when using HTTPS to connect to etcd
 	HttpListen    string        // REST API endpoint (IPaddress:PORT) for netchecker server to listen to
 	PingTimeout   time.Duration // etcd ping timeout (sec)
 	ReportTTL     time.Duration // TTL for Agent report data when etcd is in use (sec)


### PR DESCRIPTION
Support of using SSL to connect to etcd was added in https://github.com/Mirantis/k8s-netchecker-server/pull/112 
Now, CA file can also be provided for SSL when using etcd.
