### PR TITLE
CollectAgentsMetrics logic depends on persistent storage in use

### DIFF
--- a/pkg/utils/config.go
+++ b/pkg/utils/config.go
@@ -34,6 +34,7 @@ type AppConfig struct {
 	HttpListen    string        // REST API endpoint (IPaddress:PORT) for netchecker server to listen to
 	PingTimeout   time.Duration // etcd ping timeout (sec)
 	ReportTTL     time.Duration // TTL for Agent report data when etcd is in use (sec)
+	CheckInterval time.Duration // Interval of checking that agents data is up-to-date
 }
 
 var main_config *AppConfig

--- a/pkg/utils/handler.go
+++ b/pkg/utils/handler.go
@@ -79,7 +79,7 @@ func (h *Handler) UpdateAgents(rw http.ResponseWriter, r *http.Request, rp httpr
 	}
 
 	h.Metrics[agentName] = NewAgentMetrics(&agentData)
-	UpdateAgentBaseMetrics(h.Metrics[agentName], true, false)
+	UpdateAgentBaseMetrics(h.Metrics, agentName, true, false)
 	UpdateAgentProbeMetrics(agentData, h.Metrics[agentName])
 }
 
@@ -140,7 +140,7 @@ func (h *Handler) CollectAgentsMetrics(checkInterval time.Duration, useKubeClien
 					deltaInIntervals := time.Now().Sub(agentsData[name].LastUpdated).Seconds() /
 							float64(agentsData[name].ReportInterval)
 					if int(deltaInIntervals) > (h.Metrics[name].ErrorsFromLastReport + 1) {
-						UpdateAgentBaseMetrics(h.Metrics[name], false, true)
+						UpdateAgentBaseMetrics(h.Metrics, name, false, true)
 					}
 				}
 			}
@@ -154,7 +154,7 @@ func (h *Handler) CollectAgentsMetrics(checkInterval time.Duration, useKubeClien
 			for _, name := range absent {
 				if _, exists := h.Metrics[name]; exists {
 					if h.Metrics[name].ErrorsFromLastReport == 0 {
-						UpdateAgentBaseMetrics(h.Metrics[name], false, true)
+						UpdateAgentBaseMetrics(h.Metrics, name, false, true)
 					}
 				}
 			}

--- a/pkg/utils/handler.go
+++ b/pkg/utils/handler.go
@@ -23,7 +23,6 @@ import (
 	"github.com/julienschmidt/httprouter"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/urfave/negroni"
-	"gerrit/mcp/projectcalico/cni-plugin/k8s"
 )
 
 func NewHandler(useKubeClient bool) (*Handler, error) {

--- a/pkg/utils/handler.go
+++ b/pkg/utils/handler.go
@@ -23,21 +23,21 @@ import (
 	"github.com/julienschmidt/httprouter"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/urfave/negroni"
+	"gerrit/mcp/projectcalico/cni-plugin/k8s"
 )
 
-func NewHandler() (*Handler, error) {
-	appConfig := GetOrCreateConfig()
-
+func NewHandler(useKubeClient bool) (*Handler, error) {
 	h := &Handler{
 		Metrics: NcAgentMetrics{},
 	}
 
 	var err error
 
-	if appConfig.UseKubeClient {
+	if useKubeClient {
+		// use k8s TPR as a persistent storage for agents data
 		h.Agents, err = NewK8sStorer()
 	} else {
-		// use etcd for store states instead k8s 3d-part
+		// use etcd as a persistent storage for agents data
 		h.Agents, err = NewEtcdStorer()
 	}
 
@@ -131,16 +131,32 @@ func (h *Handler) CleanCache(handle httprouter.Handle) httprouter.Handle {
 	}
 }
 
-func (h *Handler) CollectAgentsMetrics() {
+func (h *Handler) CollectAgentsMetrics(checkInterval time.Duration, useKubeClient bool) {
 	for {
-		time.Sleep(5 * time.Second)
-		agentsData := h.Agents.AgentCache()
-		for name := range agentsData {
-			if _, exists := h.Metrics[name]; exists {
-				deltaInIntervals := time.Now().Sub(agentsData[name].LastUpdated).Seconds() /
-					float64(agentsData[name].ReportInterval)
-				if int(deltaInIntervals) > (h.Metrics[name].ErrorsFromLastReport + 1) {
-					UpdateAgentBaseMetrics(h.Metrics[name], false, true)
+		time.Sleep(checkInterval)
+		if useKubeClient {
+			agentsData := h.Agents.AgentCache()
+			for name := range agentsData {
+				if _, exists := h.Metrics[name]; exists {
+					deltaInIntervals := time.Now().Sub(agentsData[name].LastUpdated).Seconds() /
+							float64(agentsData[name].ReportInterval)
+					if int(deltaInIntervals) > (h.Metrics[name].ErrorsFromLastReport + 1) {
+						UpdateAgentBaseMetrics(h.Metrics[name], false, true)
+					}
+				}
+			}
+		} else {
+			absent, _, err := h.Agents.CheckAgents()
+			if err != nil {
+				message := fmt.Sprintf(
+					"Metrics update: error checking the agents: %v", err)
+				glog.Error(message)
+			}
+			for _, name := range absent {
+				if _, exists := h.Metrics[name]; exists {
+					if h.Metrics[name].ErrorsFromLastReport == 0 {
+						UpdateAgentBaseMetrics(h.Metrics[name], false, true)
+					}
 				}
 			}
 		}

--- a/pkg/utils/metrics.go
+++ b/pkg/utils/metrics.go
@@ -172,15 +172,17 @@ func tryRegisterGaugeVec(m *prometheus.GaugeVec) (*prometheus.GaugeVec, bool) {
 
 // UpdateAgentBaseMetrics function updates basic metrics with reports and
 // error counters
-func UpdateAgentBaseMetrics(am AgentMetrics, report, error bool) {
+func UpdateAgentBaseMetrics(am NcAgentMetrics, name string, report, error bool) {
+	agent := am[name]
 	if report {
-		am.ReportCount.Inc()
-		am.ErrorsFromLastReport = 0
+		agent.ReportCount.Inc()
+		agent.ErrorsFromLastReport = 0
 	}
 	if error {
-		am.ErrorCount.Inc()
-		am.ErrorsFromLastReport += 1
+		agent.ErrorCount.Inc()
+		agent.ErrorsFromLastReport += 1
 	}
+	am[name] = agent
 }
 
 // UpdateAgentProbeMetrics function updates HTTP probe metrics.


### PR DESCRIPTION
Previously used method of checking outdated information about agents
does not work properly when etcd is in use (it reports false positive
when data from agents is not updated). Now, dedicated branch is added
for the case of using etcd and Agents.CheckAgents() is called there
to get agents whose data is outdated (missing).
Also, interval of checking that agents data is up-to-date can now be
set via command-line ("-check-interval") in seconds.

Related issue: https://github.com/Mirantis/k8s-netchecker-server/issues/80
Related pull: https://github.com/Mirantis/k8s-netchecker-server/pull/111