### PR TITLE
Move helm deployment to namespace and add RBAC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ services:
   - docker
 language: go
 go:
-  - 1.7.x
+  - 1.8.x
 install:
   - make get-deps
 script:

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,8 @@ VENDOR_DIR = vendor
 ROOT_DIR = $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 
 # kubeadm-dind-cluster supports k8s versions:
-# "v1.4", "v1.5" and "v1.6".
-DIND_CLUSTER_VERSION ?= v1.5
+# "v1.6", "v1.7" and "v1.8".
+DIND_CLUSTER_VERSION ?= v1.8
 
 VERSION=$(shell date +'%Y%m%d-%H:%M:%S-%Z')
 
@@ -39,7 +39,7 @@ BUILD_IMAGE_MARKER = .build-image.complete
 ifeq ($(DOCKER_BUILD), yes)
 	_DOCKER_GOPATH = /go
 	_DOCKER_WORKDIR = $(_DOCKER_GOPATH)/src/github.com/Mirantis/k8s-netchecker-server/
-	_DOCKER_IMAGE  = golang:1.8-alpine
+	_DOCKER_IMAGE  = golang:1.8
 	DOCKER_EXEC = docker run --rm -it -v "$(ROOT_DIR):$(_DOCKER_WORKDIR)" \
 		-w "$(_DOCKER_WORKDIR)" $(_DOCKER_IMAGE)
 else

--- a/helm-chart/netchecker-server/templates/pod.yaml
+++ b/helm-chart/netchecker-server/templates/pod.yaml
@@ -6,6 +6,7 @@ metadata:
     app: {{ .Values.app.name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 spec:
+  serviceAccountName: {{ .Values.rbac.serviceaccount }}
   containers:
     - name: {{ .Values.container.name }}
       image: {{ .Values.image.repository }}:{{ .Values.image.tag }}

--- a/helm-chart/netchecker-server/templates/rbac-config.yaml
+++ b/helm-chart/netchecker-server/templates/rbac-config.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.rbac.serviceaccount }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.rbac.clusterrole }}
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - "*"
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs: ["list", "get"]
+- apiGroups:
+  - network-checker.ext
+  resources:
+  - agents
+  verbs:
+  - "*"
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.rbac.clusterrolebinding }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.rbac.clusterrole }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.rbac.serviceaccount }}
+    namespace: {{ .Release.Namespace }}

--- a/helm-chart/netchecker-server/values.yaml
+++ b/helm-chart/netchecker-server/values.yaml
@@ -22,3 +22,8 @@ service:
   externalPort: 8081
   internalPort: 8081
   nodePort: 31081
+
+rbac:
+  serviceaccount: nechecker-operator
+  clusterrole: nechecker-operator
+  clusterrolebinding: nechecker-operator

--- a/scripts/helm_install_and_deploy.sh
+++ b/scripts/helm_install_and_deploy.sh
@@ -27,6 +27,8 @@ HELM_DEBUG=${HELM_DEBUG:-"--debug"}
 NETCHECKER_REPO=${NETCHECKER_REPO:-}
 KUBECTL_DIR="${KUBECTL_DIR:-${HOME}/.kubeadm-dind-cluster}"
 PATH="${KUBECTL_DIR}:${PATH}"
+NS=${NS:-netchecker}
+REAL_NS="--namespace=${1:-$NS}"
 
 
 function wait-for-tiller-pod-ready() {
@@ -88,13 +90,13 @@ function lint-helm {
 function deploy-helm {
   if [ "${NETCHECKER_REPO}" == "k8s-netchecker-server" ]; then
     pushd "../${NETCHECKER_REPO}" &> /dev/null
-    helm "${HELM_DEBUG}" install ./"${HELM_SERVER_PATH}"/
+    helm "${HELM_DEBUG}" install ${REAL_NS} ./"${HELM_SERVER_PATH}"/
     popd &> /dev/null
-    helm "${HELM_DEBUG}" install ./"${HELM_AGENT_PATH}"/
+    helm "${HELM_DEBUG}" install ${REAL_NS} ./"${HELM_AGENT_PATH}"/
   else
-    helm "${HELM_DEBUG}" install ./"${HELM_SERVER_PATH}"/
+    helm "${HELM_DEBUG}" install ${REAL_NS} ./"${HELM_SERVER_PATH}"/
     pushd "../${NETCHECKER_REPO}" &> /dev/null
-    helm "${HELM_DEBUG}" install ./"${HELM_AGENT_PATH}"/
+    helm "${HELM_DEBUG}" install ${REAL_NS} ./"${HELM_AGENT_PATH}"/
     popd &> /dev/null
   fi
   helm "${HELM_DEBUG}" list

--- a/scripts/kubeadm_dind_cluster.sh
+++ b/scripts/kubeadm_dind_cluster.sh
@@ -22,8 +22,8 @@ set -o nounset
 NUM_NODES=${NUM_NODES:-3}
 KUBEADM_SCRIPT_URL=${KUBEADM_SCRIPT_URL:-https://cdn.rawgit.com/Mirantis/kubeadm-dind-cluster/master/fixed/dind-cluster}
 # kubeadm-dind-cluster supports k8s versions:
-# "v1.4", "v1.5" and "v1.6".
-DIND_CLUSTER_VERSION=${DIND_CLUSTER_VERSION:-v1.7}
+# "v1.6", "v1.7" and "v1.8".
+DIND_CLUSTER_VERSION=${DIND_CLUSTER_VERSION:-v1.8}
 
 
 function kubeadm-dind-cluster {


### PR DESCRIPTION
Add Kubernetes v1.8 support:

- Deploy NC in a namespace for better access controll and limits
- Add RBAC to Helm chart
- Switch kubeadm-dind-cluster version from 1.5 to 1.8 in tests
- Switch Travis-CI to go-1.8.x to match containerized build
- Change golang:1.8-alpine golang:1.8 because 'bash' and 'git' are needed.

Closes #120 