### PR TITLE
Increase delay in e2e to test agent updates

### DIFF
--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -117,7 +117,7 @@ var _ = ginkgo.Describe("Basic", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// ensure agents are up and they have sent their reports to the server
-		time.Sleep(15 * time.Second)
+		time.Sleep(45 * time.Second)
 
 		services := getServices(clientset, ns)
 		ncService := false


### PR DESCRIPTION
With 15 sec delay we're testing that server is able to add agents to K8s Custom Resources. But we're not checking that server is able to update them and make sure agents are up to date.

Increasing delay to 45 seconds will make sure server/agents have enough time to detect outdated state.